### PR TITLE
Fixed crached if task id in integer format

### DIFF
--- a/lib/issue_changeset_patch.rb
+++ b/lib/issue_changeset_patch.rb
@@ -35,7 +35,7 @@ module IssueChangesetPatch
         end
 
         def find_referenced_issue_by_id_with_full_id(id)
-            if id.is_a?(String) && id.include?('-')
+            if id.is_a?(String) && id.to_s.include?('-')
                 find_referenced_issue_by_full_id(id)
             else
                 find_referenced_issue_by_id_without_full_id(id)


### PR DESCRIPTION
Fixed crash of the application if there are integer task IDs in the commit history in the repository. For example # 1234.

```
NoMethodError (undefined method `include?' for 2636:Fixnum):
  plugins/issue_id/lib/issue_changeset_patch.rb:38:in `find_referenced_issue_by_id_with_full_id'
  app/models/changeset.rb:134:in `block (2 levels) in scan_comment_for_issue_ids'
  app/models/changeset.rb:133:in `each'
  app/models/changeset.rb:133:in `block in scan_comment_for_issue_ids'
  app/models/changeset.rb:129:in `scan'
  app/models/changeset.rb:129:in `scan_comment_for_issue_ids'
  plugins/issue_id/lib/issue_changeset_patch.rb:77:in `scan_comment_for_issue_ids_with_full_ids'
  app/models/changeset.rb:102:in `scan_for_issues'
  app/models/repository/git.rb:218:in `save_revision'
  app/models/repository/git.rb:207:in `block (2 levels) in save_revisions'
  app/models/repository/git.rb:204:in `block in save_revisions'
  app/models/repository/git.rb:203:in `each'
  app/models/repository/git.rb:203:in `save_revisions'
  app/models/repository/git.rb:153:in `fetch_changesets'
  app/controllers/repositories_controller.rb:114:in `show'
  lib/redmine/sudo_mode.rb:63:in `sudo_mode'
```